### PR TITLE
Use ggpackets %+% in place of standard +

### DIFF
--- a/R/plotting.R
+++ b/R/plotting.R
@@ -209,7 +209,7 @@ geom_auspol_bar <- function(include_labels=TRUE,
   }
 
   if(!is.null(reference_line)){
-    ggpck <- ggpck + geom_vline(.id="ref_line",xintercept = reference_line,...)
+    ggpck <- ggpck %+% geom_vline(.id="ref_line",xintercept = reference_line,...)
   }
 
   return(ggpck)


### PR DESCRIPTION
Hi! I'm the author of `ggpackets` and was perusing GitHub for uses when I stumbled upon your package. Very cool application! I hope you're finding it helpful for your use case.

While looking through the code, I found one small change that I think might be considered a typo. Of course, I don't know your exact use case, so feel free to disregard if you prefer it as is. You use the `%+%` operator throughout in other cases, so this looks like a typo to my eye.

In any case, I was excited to see the use of the package and the features that you can provide with it. Should you encounter any issues or ideas for improvement, bug reports and feature requests are always welcome!